### PR TITLE
Fix example and local image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm i electron-splashscreen
 ## Example
 
 ```jsx
-import { initSplashScreen, Office } from 'electron-splashscreen';
+import { initSplashScreen, OfficeTemplate } from 'electron-splashscreen';
 import isDev from 'electron-is-dev';
 import { resolve } from 'app-root-path';
 
@@ -57,7 +57,7 @@ app.on('ready', async () => {
   const hideSplashscreen = initSplashScreen({
     mainWindow,
     icon: isDev ? resolve('assets/icon.ico') : undefined,
-    url: Office,
+    url: OfficeTemplate,
     width: 500,
     height: 300,
     brand: 'My Brand',

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,10 @@ export const initSplashScreen = ({
     resizable: false,
     movable: false,
     icon,
-    backgroundColor
+    backgroundColor,
+    webPreferences: {
+      webSecurity: false
+    }
   });
 
   const args = {


### PR DESCRIPTION
This fixes the example and disables Websecurity in the browser window, so that local images can be used